### PR TITLE
changing volume adjustment to use incremental adjustements, fixing so…

### DIFF
--- a/src/PcmPlayer.ts
+++ b/src/PcmPlayer.ts
@@ -40,9 +40,9 @@ export class PcmPlayer {
     this.feedWorklet(source)
   }
 
-  volume(volume: number) {
+  volume(volume: number, duration: number =0) {
     if (this.gainNode) {
-      this.gainNode.gain.value = volume
+      this.gainNode.gain.setTargetAtTime(volume, this.context!.currentTime + duration, duration / 3)
     }
   }
 
@@ -66,7 +66,7 @@ export class PcmPlayer {
         channels: this.channels,
       },
     })
-    this.worklet.connect(this.context.destination)
+    this.worklet.connect(this.gainNode!)
 
     for (const source of this.buffers) {
       this.feedWorklet(source)


### PR DESCRIPTION
Whilst working through the navigation issues on node-carplay I found the volume control is not actually working, due to both issues in node-carplay and also pcm-ringbuf-player. The fix for this library was the the sink was being connected directly to the source, bypassing the gainNode.

Also changed volume control to a scale.